### PR TITLE
:memo: Fix README discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Rustorio &emsp; [![Latest Version]][crates.io] [![Docs]][docs.rs] [![Discord]][discord]
+# Rustorio &emsp; [![Latest Version]][crates.io] [![Docs]][docs.rs] [![Discord]][discord.gg]
 
 [Latest Version]: https://img.shields.io/crates/v/rustorio.svg
 [crates.io]: https://crates.io/crates/rustorio
 [Docs]: https://img.shields.io/docsrs/rustorio.svg
 [docs.rs]: https://docs.rs/rustorio
 [Discord]: https://dcbadge.limes.pink/api/server/uKJugp85Fk?style=flat
-[discord]: https://discord.gg/uKJugp85Fk
+[discord.gg]: https://discord.gg/uKJugp85Fk
 
 The first game written _and played_ entirely in Rust's type system. Not just do you play by
 writing Rust code, the rules of the game are enforced by the Rust compiler! If


### PR DESCRIPTION
With the image called "Discord" and the link called "discord", github's case-insensitive renderer sends clicks to the image itself.