### PR TITLE
:bug: Bind input and output lifetimes to tick

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,3 @@
 {
-    "rust-analyzer.cargo.features": [
-        "server"
-    ]
+    "rust-analyzer.cargo.features": []
 }

--- a/rustorio-engine/src/machine.rs
+++ b/rustorio-engine/src/machine.rs
@@ -85,13 +85,13 @@ impl<R: RecipeEx> Machine<R> {
     }
 
     /// Update internal state and access input buffers.
-    pub fn inputs(&mut self, tick: &Tick) -> &mut R::Inputs {
+    pub fn inputs<'a>(&'a mut self, tick: &'a Tick) -> &'a mut R::Inputs {
         self.tick(tick);
         &mut self.inputs
     }
 
     /// Update internal state and access output buffers.
-    pub fn outputs(&mut self, tick: &Tick) -> &mut R::Outputs {
+    pub fn outputs<'a>(&'a mut self, tick: &'a Tick) -> &'a mut R::Outputs {
         self.tick(tick);
         &mut self.outputs
     }

--- a/rustorio/src/buildings.rs
+++ b/rustorio/src/buildings.rs
@@ -56,7 +56,7 @@ impl<R: AssemblerRecipe> Assembler<R> {
     }
 
     /// Update internal state and access input buffers.
-    pub fn inputs(&mut self, tick: &Tick) -> &mut <R as Recipe>::Inputs {
+    pub fn inputs<'a>(&'a mut self, tick: &'a Tick) -> &'a mut <R as Recipe>::Inputs {
         self.0.inputs(tick)
     }
 
@@ -66,7 +66,7 @@ impl<R: AssemblerRecipe> Assembler<R> {
     }
 
     /// Update internal state and access output buffers.
-    pub fn outputs(&mut self, tick: &Tick) -> &mut <R as Recipe>::Outputs {
+    pub fn outputs<'a>(&'a mut self, tick: &'a Tick) -> &'a mut <R as Recipe>::Outputs {
         self.0.outputs(tick)
     }
 
@@ -108,7 +108,7 @@ impl<R: FurnaceRecipe> Furnace<R> {
     }
 
     /// Update internal state and access input buffers.
-    pub fn inputs(&mut self, tick: &Tick) -> &mut <R as Recipe>::Inputs {
+    pub fn inputs<'a>(&'a mut self, tick: &'a Tick) -> &'a mut <R as Recipe>::Inputs {
         self.0.inputs(tick)
     }
 
@@ -118,7 +118,7 @@ impl<R: FurnaceRecipe> Furnace<R> {
     }
 
     /// Update internal state and access output buffers.
-    pub fn outputs(&mut self, tick: &Tick) -> &mut <R as Recipe>::Outputs {
+    pub fn outputs<'a>(&'a mut self, tick: &'a Tick) -> &'a mut <R as Recipe>::Outputs {
         self.0.outputs(tick)
     }
 
@@ -167,7 +167,7 @@ where
     }
 
     /// Get a mutable reference to input buffers.
-    pub fn inputs(&mut self, tick: &Tick) -> &mut <TechRecipe<T> as Recipe>::Inputs {
+    pub fn inputs<'a>(&'a mut self, tick: &'a Tick) -> &'a mut <TechRecipe<T> as Recipe>::Inputs {
         self.0.inputs(tick)
     }
 
@@ -177,7 +177,7 @@ where
     }
 
     /// Get a mutable reference to output buffers.
-    pub fn outputs(&mut self, tick: &Tick) -> &mut <TechRecipe<T> as Recipe>::Outputs {
+    pub fn outputs<'a>(&'a mut self, tick: &'a Tick) -> &'a mut <TechRecipe<T> as Recipe>::Outputs {
         self.0.outputs(tick)
     }
 }

--- a/rustorio/tests/standard-simple.rs
+++ b/rustorio/tests/standard-simple.rs
@@ -36,7 +36,8 @@ fn user_main(mut tick: Tick, starting_resources: StartingResources) -> (Tick, Bu
     let mut iron_furnace = Furnace::build(&tick, IronSmelting, iron);
 
     let mut copper_furnace = loop {
-        iron_furnace.inputs(&tick).0 += iron_territory.hand_mine::<1>(&mut tick);
+        let ore = iron_territory.hand_mine::<1>(&mut tick);
+        iron_furnace.inputs(&tick).0 += ore;
         if let Ok(iron) = iron_furnace.outputs(&tick).0.bundle() {
             break Furnace::build(&tick, CopperSmelting, iron);
         }
@@ -51,9 +52,11 @@ fn user_main(mut tick: Tick, starting_resources: StartingResources) -> (Tick, Bu
         || copper_furnace.outputs(&tick).0.amount() < 30
     {
         if copper_furnace.inputs(&tick).0.amount() < iron_furnace.inputs(&tick).0.amount() {
-            copper_furnace.inputs(&tick).0 += copper_territory.hand_mine::<1>(&mut tick);
+            let ore = copper_territory.hand_mine::<1>(&mut tick);
+            copper_furnace.inputs(&tick).0 += ore;
         } else {
-            iron_furnace.inputs(&tick).0 += iron_territory.hand_mine::<1>(&mut tick);
+            let ore = iron_territory.hand_mine::<1>(&mut tick);
+            iron_furnace.inputs(&tick).0 += ore;
         }
     }
     for _ in 0..3 {
@@ -140,9 +143,11 @@ fn user_main(mut tick: Tick, starting_resources: StartingResources) -> (Tick, Bu
 
     let mut lab = loop {
         if copper_furnace.inputs(&tick).0.amount() < iron_furnace.inputs(&tick).0.amount() {
-            copper_furnace.inputs(&tick).0 += copper_territory.hand_mine::<1>(&mut tick);
+            let ore = copper_territory.hand_mine::<1>(&mut tick);
+            copper_furnace.inputs(&tick).0 += ore;
         } else {
-            iron_furnace.inputs(&tick).0 += iron_territory.hand_mine::<1>(&mut tick);
+            let ore = iron_territory.hand_mine::<1>(&mut tick);
+            iron_furnace.inputs(&tick).0 += ore;
         }
         iron_furnace.inputs(&tick).0 += iron_territory.resources(&tick).empty();
         copper_furnace.inputs(&tick).0 += copper_territory.resources(&tick).empty();


### PR DESCRIPTION
Previously it was possible to borrow the input of a machine, gain resources by letting ticks pass, and then put them in the inputs from the past. By limiting the lifetime of the borrow to that of the tick, it is not possible to let ticks pass while those borrows exist.