### PR TITLE
Re-export `TechRecipe` from the engine

### DIFF
--- a/rustorio-engine/src/lib.rs
+++ b/rustorio-engine/src/lib.rs
@@ -77,7 +77,7 @@ pub mod mod_reexports {
         gamemodes::GameMode,
         play,
         recipe::{HandRecipe, Recipe},
-        research::{ResearchPoint, Technology},
+        research::{ResearchPoint, TechRecipe, Technology},
         resources::{Bundle, InsufficientResourceError, Resource, ResourceType},
         tick::Tick,
     };


### PR DESCRIPTION
I had to add `rustorio_engine` as a dependency to my game just to get access to this type. I use it for recipe-generic computations involving labs.